### PR TITLE
Update bin to update

### DIFF
--- a/bin/app
+++ b/bin/app
@@ -10,6 +10,7 @@ require 'finder'
 require 'io/console'
 require 'null_action'
 require 'pager'
+require 'updater'
 require 'user_interface'
 require 'validator'
 
@@ -19,6 +20,7 @@ actions = [
   Pager.new(user_interface, array_database),
   Creator.new(user_interface, array_database),
   Finder.new(user_interface, array_database),
+  Updater.new(user_interface, array_database),
   NullAction.new
 ]
 

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Constants
+  ACTIONS_COUNT = 5
   ANOTHER_CONTACT_PROMPT = 'Add another contact? (y/n): '
   ANOTHER_EDIT_PROMPT = 'Update another detail? (y/n): '
   ANOTHER_SEARCH_PROMPT = 'Search again? (y/n): '
@@ -8,6 +9,7 @@ module Constants
   CLEAR_COMMAND = "\033[H\033[2J"
   CONTACT_INDEX_PROMPT = 'Enter contact index: '
   CONTINUE_MESSAGE = 'Press any key to continue '
+  EXIT_CHOICE = 5
   FIELD_CHOICE_PROMPT = 'Which detail of the contact would you like to edit? '
   ERROR_MESSAGE = 'Wrong input. Please try again: '
   NO_CONTACTS_MESSAGE = 'No contacts were found.'
@@ -47,6 +49,4 @@ module Constants
   VALID_YES_NO_REPLY = /^[yn]$/i.freeze
 
   YES_REPLY = 'y'
-
-  EXIT_CHOICE = 5
 end

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -23,7 +23,8 @@ module Constants
   1) List contacts
   2) Add contact
   3) Search contact
-  4) Exit the program
+  4) Update contact
+  5) Exit the program
 
   Choose a menu option: }
 
@@ -47,5 +48,5 @@ module Constants
 
   YES_REPLY = 'y'
 
-  EXIT_CHOICE = 4
+  EXIT_CHOICE = 5
 end

--- a/lib/updater.rb
+++ b/lib/updater.rb
@@ -19,7 +19,7 @@ class Updater
 
   private
 
-  def edit_contacts(contact_index, contact)
+  def edit_contact_fields(contact_index, contact)
     loop do
       new_data = user_interface.edit_field
 
@@ -35,7 +35,7 @@ class Updater
       contact = database.contact_at(contact_index)
 
       user_interface.display_contact(contact)
-      edit_contacts(contact_index, contact)
+      edit_contact_fields(contact_index, contact)
       break unless user_interface.update_another_contact?
     end
   end

--- a/lib/updater.rb
+++ b/lib/updater.rb
@@ -19,11 +19,9 @@ class Updater
 
   private
 
-  def edit_contacts(contact_index)
-    contact = database.contact_at(contact_index)
-
+  def edit_contacts(contact_index, contact)
     loop do
-      new_data = user_interface.edit_field(contact)
+      new_data = user_interface.edit_field
 
       database.update(contact_index, new_data)
       user_interface.display_contact(contact)
@@ -34,7 +32,10 @@ class Updater
   def update_contacts
     loop do
       contact_index = user_interface.choose_contact(database.all)
-      edit_contacts(contact_index)
+      contact = database.contact_at(contact_index)
+
+      user_interface.display_contact(contact)
+      edit_contacts(contact_index, contact)
       break unless user_interface.update_another_contact?
     end
   end

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -65,8 +65,7 @@ class UserInterface
     ask_for_index(contacts.length).to_i
   end
 
-  def edit_field(contact)
-    display_contact(contact)
+  def edit_field
     output.print Constants::FIELD_CHOICE_PROMPT
 
     field = collect_field_name

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -11,7 +11,7 @@ class UserInterface
 
   def menu_choice
     output.print Constants::CLEAR_COMMAND, Constants::MENU_MESSAGE
-    collect_valid_input { |user_input| validator.valid_choice?(user_input) }.to_i
+    collect_valid_input { |user_input| validator.valid_choice?(user_input, Constants::ACTIONS_COUNT) }.to_i
   end
 
   def ask_for_fields

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -3,8 +3,8 @@
 require 'constants'
 
 class Validator
-  def valid_choice?(option)
-    option.match?(/^[1-#{Constants::EXIT_CHOICE}]$/)
+  def valid_choice?(option, max_choice)
+    option.match?(/^[1-#{max_choice}]$/)
   end
 
   def valid_yes_no_answer?(value)

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -4,7 +4,7 @@ require 'constants'
 
 class Validator
   def valid_choice?(option)
-    option.match?(/^[1-4]$/)
+    option.match?(/^[1-#{Constants::EXIT_CHOICE}]$/)
   end
 
   def valid_yes_no_answer?(value)

--- a/spec/controler_spec.rb
+++ b/spec/controler_spec.rb
@@ -6,7 +6,7 @@ require 'user_interface'
 require 'validator'
 
 RSpec.describe Controler do
-  let(:actions) { Array.new(5, NullAction.new) }
+  let(:actions) { Array.new(Constants::ACTIONS_COUNT, NullAction.new) }
   let(:exit_choice) { Constants::EXIT_CHOICE }
   let(:output) { StringIO.new }
 
@@ -32,7 +32,7 @@ RSpec.describe Controler do
   it 'runs the actions chosen' do
     null_action = double('NullAction', run: nil)
     ui = UserInterface.new(StringIO.new("1\n#{exit_choice}\n"), output, Validator.new)
-    controler = described_class.new(ui, Array.new(5, null_action))
+    controler = described_class.new(ui, Array.new(Constants::ACTIONS_COUNT, null_action))
 
     controler.start
 

--- a/spec/controler_spec.rb
+++ b/spec/controler_spec.rb
@@ -6,7 +6,7 @@ require 'user_interface'
 require 'validator'
 
 RSpec.describe Controler do
-  let(:actions) { Array.new(4, NullAction.new) }
+  let(:actions) { Array.new(5, NullAction.new) }
   let(:exit_choice) { Constants::EXIT_CHOICE }
   let(:output) { StringIO.new }
 
@@ -32,7 +32,7 @@ RSpec.describe Controler do
   it 'runs the actions chosen' do
     null_action = double('NullAction', run: nil)
     ui = UserInterface.new(StringIO.new("1\n#{exit_choice}\n"), output, Validator.new)
-    controler = described_class.new(ui, Array.new(4, null_action))
+    controler = described_class.new(ui, Array.new(5, null_action))
 
     controler.start
 

--- a/spec/updater_spec.rb
+++ b/spec/updater_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Updater do
       expect(output.string).to include(Constants::CONTACT_INDEX_PROMPT)
     end
 
+    it 'prints contact to be edited' do
+      run_updater_with_input(quick_exit_responces)
+
+      expect(output.string.scan(/Name:    Matt Damon/).length).to eq(2)
+    end
+
     it 'asks the user which field it wants to update and the value for it' do
       run_updater_with_input(quick_exit_responces)
 

--- a/spec/user_interface_spec.rb
+++ b/spec/user_interface_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'constants'
 require 'user_interface'
 require 'validator'
 
@@ -10,9 +9,7 @@ RSpec.describe UserInterface do
   let(:yes_reply) { Constants::YES_REPLY + "\n" }
 
   describe '#menu_choice' do
-    let(:error_message) { Constants::ERROR_MESSAGE }
-    let(:exit_choice) { Constants::EXIT_CHOICE }
-    let(:valid_input) { StringIO.new(exit_choice.to_s + "\n") }
+    let(:valid_input) { StringIO.new("1\n") }
 
     it 'prints menu of options for user to choose' do
       ui = described_class.new(valid_input, output, validator)
@@ -35,31 +32,31 @@ RSpec.describe UserInterface do
 
       user_input = ui.menu_choice
 
-      expect(user_input).to eq(exit_choice)
+      expect(user_input).to eq(1)
     end
 
     it 'reads the input again if input is invalid' do
-      input = StringIO.new("yes\n#{exit_choice}\n")
+      input = StringIO.new("yes\n1\n")
       ui = described_class.new(input, output, validator)
 
       user_input = ui.menu_choice
 
-      expect(user_input).to eq(exit_choice)
+      expect(user_input).to eq(1)
     end
 
     it 'repeats printing error message untill valid input is entered' do
-      input = StringIO.new("yes\n0\n13\n#{exit_choice}\n")
+      input = StringIO.new("yes\n0\n#{Constants::ACTIONS_COUNT + 1}\n1\n")
       ui = described_class.new(input, output, validator)
 
       ui.menu_choice
 
-      expect(output.string.scan(error_message).length).to eq(3)
+      expect(output.string.scan(Constants::ERROR_MESSAGE).length).to eq(3)
     end
 
     it 'returns a valid input' do
       ui = described_class.new(valid_input, output, validator)
 
-      expect(ui.menu_choice).to eq(exit_choice)
+      expect(ui.menu_choice).to eq(1)
     end
   end
 

--- a/spec/user_interface_spec.rb
+++ b/spec/user_interface_spec.rb
@@ -314,20 +314,11 @@ Notes:   I think he has an Oscar
   end
 
   describe '#edit_field' do
-    it 'prints contact to be edited' do
-      input = StringIO.new("name\nJoe\n")
-      ui = described_class.new(input, output, validator)
-
-      ui.edit_field(test_details)
-
-      expect(output.string).to match(/Name:    Matt Damon/)
-    end
-
     it 'prints prompt for user to enter field name to be edited' do
       input = StringIO.new("name\nJoe\n")
       ui = described_class.new(input, output, validator)
 
-      ui.edit_field(test_details)
+      ui.edit_field
 
       expect(output.string).to include(Constants::FIELD_CHOICE_PROMPT)
     end
@@ -336,7 +327,7 @@ Notes:   I think he has an Oscar
       input = StringIO.new("surname\nemail\njoe@hotmail.com\n")
       ui = described_class.new(input, output, validator)
 
-      ui.edit_field(test_details)
+      ui.edit_field
 
       expect(output.string).to include(Constants::ERROR_MESSAGE)
     end
@@ -345,7 +336,7 @@ Notes:   I think he has an Oscar
       input = StringIO.new("email\njoe@hotmail.com\n")
       ui = described_class.new(input, output, validator)
 
-      ui.edit_field(test_details)
+      ui.edit_field
 
       expect(output.string).to include(Constants::FIELDS_TO_PROMPTS[:email])
     end
@@ -354,7 +345,7 @@ Notes:   I think he has an Oscar
       input = StringIO.new("email\njoe.hotmail.com\njoe@hotmail.com\n")
       ui = described_class.new(input, output, validator)
 
-      ui.edit_field(test_details)
+      ui.edit_field
 
       expect(output.string).to include(Constants::ERROR_MESSAGE)
     end
@@ -363,7 +354,7 @@ Notes:   I think he has an Oscar
       input = StringIO.new("email\njoe@hotmail.com\n")
       ui = described_class.new(input, output, validator)
 
-      result = ui.edit_field(test_details)
+      result = ui.edit_field
 
       expect(result).to eq({ email: 'joe@hotmail.com' })
     end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Validator do
   let(:validator) { described_class.new }
 
   describe '#valid_choice?' do
-    let(:highest_choice_input) { 4 }
+    let(:highest_choice_input) { Constants::EXIT_CHOICE }
 
     it 'returns true on avaible choices' do
       result = validator.valid_choice?(highest_choice_input.to_s)

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -6,18 +6,14 @@ RSpec.describe Validator do
   let(:validator) { described_class.new }
 
   describe '#valid_choice?' do
-    let(:highest_choice_input) { Constants::EXIT_CHOICE }
-
     it 'returns true on avaible choices' do
-      result = validator.valid_choice?(highest_choice_input.to_s)
+      result = validator.valid_choice?('1', 4)
 
       expect(result).to eq(true)
     end
 
     it 'returns false on non-avaible choices' do
-      non_choice_input = (highest_choice_input + 1).to_s
-
-      result = validator.valid_choice?(non_choice_input)
+      result = validator.valid_choice?('5', 4)
 
       expect(result).to eq(false)
     end


### PR DESCRIPTION
I noticed something when running the program: When you chose to edit the same contact again, it displays the contact again which looks quite jarring as it has just been printed a line away. 

So in the last commit I have decoupled the display contact behaver from the edit_field UserInterface method as it seems more appropiate to control the displaying behaver in the Updater class. 

Also, since displaying a contact is being called there at a different point already, this kinda confirms to me that this is the best choice for constancy.